### PR TITLE
Fixing errors in brasileirao 2017 file.

### DIFF
--- a/2017/brasileirao-seriea.txt
+++ b/2017/brasileirao-seriea.txt
@@ -1,27 +1,27 @@
 Rodada 1
 [Sáb, 13/Maio]
-Flamengo        1 - 1   Atlético
+Flamengo        1 - 1   Atlético MG
 Corinthians     1 - 1   Chapecoense
 [Dom, 14/Maio]
 Fluminense      3 - 2   Santos
 Palmeiras       4 - 0   Vasco da Gama
 Cruzeiro        1 - 0   São Paulo
-Bahia           6 - 2   Atlético
+Bahia           6 - 2   Atlético PR
 Ponte Preta     4 - 0   Sport
 Avaí            0 - 0   Vitória
 Grêmio          2 - 0   Botafogo
 [Seg, 15/Maio]
-Coritiba        4 - 1   Atlético
+Coritiba        4 - 1   Atlético GO
 
 Rodada 2
 [Sáb, 20/Maio]
 Santos          1 - 0   Coritiba
-Atlético        0 - 3   Flamengo
+Atlético GO     0 - 3   Flamengo
 Chapecoense     1 - 0   Palmeiras
 [Dom, 21/Maio]
 Vasco da Gama   2 - 1   Bahia
-Atlético        1 - 2   Fluminense
-Atlético        0 - 2   Grêmio
+Atlético MG     1 - 2   Fluminense
+Atlético PR     0 - 2   Grêmio
 Vitória         0 - 1   Corinthians
 Botafogo        2 - 0   Ponte Preta
 Sport           1 - 1   Cruzeiro
@@ -34,10 +34,10 @@ Vasco da Gama   3 - 2   Fluminense
 São Paulo       2 - 0   Palmeiras
 Vitória         0 - 1   Coritiba
 [Dom, 28/Maio]
-Atlético        2 - 2   Ponte Preta
+Atlético MG     2 - 2   Ponte Preta
 Santos          0 - 1   Cruzeiro
-Atlético        1 - 1   Flamengo
-Atlético        0 - 1   Corinthians
+Atlético PR     1 - 1   Flamengo
+Atlético GO     0 - 1   Corinthians
 Sport           4 - 3   Grêmio
 Botafogo        1 - 0   Bahia
 [Seg, 29/Maio]
@@ -45,31 +45,31 @@ Chapecoense     2 - 0   Avaí
 
 Rodada 4
 [Sáb, 03/Junho]
-Coritiba        1 - 0   Atlético
+Coritiba        1 - 0   Atlético PR
 Fluminense      2 - 1   Vitória
 Corinthians     2 - 0   Santos
 [Dom, 04/Junho]
 Flamengo        0 - 0   Botafogo
 Avaí            1 - 0   Sport
-Palmeiras       0 - 0   Atlético
+Palmeiras       0 - 0   Atlético MG
 Grêmio          2 - 0   Vasco da Gama
 Ponte Preta     1 - 0   São Paulo
 Cruzeiro        0 - 2   Chapecoense
 [Seg, 05/Junho]
-Bahia           3 - 0   Atlético
+Bahia           3 - 0   Atlético GO
 
 Rodada 5
 [Ter, 06/Junho]
-Fluminense      1 - 1   Atlético
+Fluminense      1 - 1   Atlético PR
 [Qua, 07/Junho]
-Atlético        1 - 0   Avaí
+Atlético MG     1 - 0   Avaí
 Coritiba        1 - 0   Palmeiras
 Santos          1 - 0   Botafogo
 Vasco da Gama   2 - 5   Corinthians
 Sport           2 - 0   Flamengo
 [Qui, 08/Junho]
 São Paulo       2 - 0   Vitória
-Atlético        3 - 0   Ponte Preta
+Atlético GO     3 - 0   Ponte Preta
 Chapecoense     3 - 6   Grêmio
 Bahia           1 - 0   Cruzeiro
 
@@ -80,20 +80,20 @@ Vasco da Gama   2 - 1   Sport
 [Dom, 11/Junho]
 Botafogo        2 - 2   Coritiba
 Corinthians     3 - 2   São Paulo
-Vitória         2 - 0   Atlético
+Vitória         2 - 0   Atlético MG
 Ponte Preta     3 - 2   Chapecoense
 Avaí            1 - 1   Flamengo
-Cruzeiro        2 - 0   Atlético
-Atlético        0 - 2   Santos
+Cruzeiro        2 - 0   Atlético GO
+Atlético PR     0 - 2   Santos
 [Seg, 12/Junho]
 Grêmio          1 - 0   Bahia
 
 Rodada 7
 [Qua, 14/Junho]
 Sport           0 - 0   São Paulo
-Atlético        0 - 1   Atlético
+Atlético MG     0 - 1   Atlético PR
 Vitória         2 - 2   Botafogo
-Atlético        3 - 1   Avaí
+Atlético GO     3 - 1   Avaí
 Flamengo        2 - 0   Ponte Preta
 Santos          1 - 0   Palmeiras
 Corinthians     1 - 0   Cruzeiro
@@ -104,13 +104,13 @@ Fluminense      0 - 2   Grêmio
 
 Rodada 8
 [Sáb, 17/Junho]
-Atlético        0 - 1   Atlético
+Atlético GO     0 - 1   Atlético PR
 Vasco da Gama   1 - 0   Avaí
 Santos          0 - 0   Ponte Preta
 [Dom, 18/Junho]
 Coritiba        0 - 0   Corinthians
 Fluminense      2 - 2   Flamengo
-São Paulo       1 - 2   Atlético
+São Paulo       1 - 2   Atlético MG
 Bahia           2 - 4   Palmeiras
 Chapecoense     0 - 2   Botafogo
 Sport           1 - 3   Vitória
@@ -121,10 +121,10 @@ Rodada 9
 [Qua, 21/Junho]
 Vitória         0 - 2   Santos
 Botafogo        3 - 1   Vasco da Gama
-Palmeiras       1 - 0   Atlético
+Palmeiras       1 - 0   Atlético GO
 Avaí            0 - 3   Fluminense
-Atlético        1 - 0   São Paulo
-Atlético        2 - 2   Sport
+Atlético PR     1 - 0   São Paulo
+Atlético MG     2 - 2   Sport
 [Qui, 22/Junho]
 Corinthians     3 - 0   Bahia
 Ponte Preta     1 - 0   Cruzeiro
@@ -135,14 +135,14 @@ Rodada 10
 [Sáb, 24/Junho]
 Santos          0 - 1   Sport
 [Dom, 25/Junho]
-Vasco da Gama   1 - 0   Atlético
-Atlético        4 - 1   Vitória
+Vasco da Gama   1 - 0   Atlético GO
+Atlético PR     4 - 1   Vitória
 Cruzeiro        2 - 0   Coritiba
 Grêmio          0 - 1   Corinthians
 São Paulo       1 - 1   Fluminense
 Ponte Preta     1 - 2   Palmeiras
 Bahia           0 - 1   Flamengo
-Chapecoense     0 - 1   Atlético
+Chapecoense     0 - 1   Atlético MG
 [Seg, 26/Junho]
 Botafogo        0 - 2   Avaí
 
@@ -156,7 +156,7 @@ Corinthians	1 - 0	Botafogo
 Atlético MG	3 - 1	Cruzeiro
 Sport		1 - 0	Atlético PR
 Vitória		0 - 0	Bahia
-Coritiba	2 - 2	Vasco
+Coritiba	2 - 2	Vasco da Gama
 Avaí		0 - 0	Ponte Preta
 [Seg, 03/07]
 Fluminense	3 - 3	Chapecoense
@@ -164,7 +164,7 @@ Fluminense	3 - 3	Chapecoense
 Rodada 12
 [Sáb, 08/07]
 Atlético GO	1 - 2	Vitória
-Vasco		0 - 1	Flamengo
+Vasco da Gama	0 - 1	Flamengo
 Corinthians	2 - 0	Ponte Preta
 [Dom, 09/07]
 Chapecoense	1 - 1	Atlético PR
@@ -183,7 +183,7 @@ Ponte Preta	0 - 3	Bahia
 Fluminense	0 - 1	Botafogo
 Palmeiras	0 - 2	Corinthians
 Atlético PR	0 - 2	Cruzeiro
-Vitória		1 - 4	Vasco
+Vitória		1 - 4	Vasco da Gama
 [Qui, 13/07]
 Flamengo	0 - 1	Grêmio
 São Paulo	2 - 2	Atlético GO
@@ -195,10 +195,10 @@ Rodada 14
 Corinthians	2 - 2	Atlético PR
 [Dom, 16/07]
 Palmeiras	4 - 2	Vitória
-Vasco		0 - 0	Santos
+Vasco da Gama	0 - 0	Santos
 Cruzeiro	1 - 1	Flamengo
 Grêmio		3 - 1	Ponte Preta
-Atlético GO	1 - 2	Altético MG
+Atlético GO	1 - 2	Atlético MG
 Chapecoense	2 - 0	São Paulo
 Coritiba	1 - 2	Fluminense
 Bahia		1 - 1	Avaí
@@ -210,9 +210,9 @@ Rodada 15
 Santos		1 - 0	Chapecoense
 Vitória		1 - 3	Grêmio
 Ponte Preta	4 - 0	Coritiba
-Avaí		0 - 0	Avaí
+Avaí		0 - 0	Corinthians
 Flamengo	2 - 2	Palmeiras
-São Paulo	1 - 0	Vasco
+São Paulo	1 - 0	Vasco da Gama
 Atlético MG	0 - 2	Bahia
 [Qui, 20/07]
 Fluminense	1 - 1	Cruzeiro
@@ -225,12 +225,12 @@ Vitória		1 - 2	Chapecoense
 Flamengo	2 - 1	Coritiba
 [Dom, 23/07]
 Santos		3 - 0	Bahia
-Fluminense	0 - 1	Corithians
+Fluminense	0 - 1	Corinthians
 Sport		0 - 2	Palmeiras
 Avaí		1 - 0	Cruzeiro
-Atlético MG	1 - 2	Vasco
+Atlético MG	1 - 2	Vasco da Gama
 Atlético PR	0 - 2	Ponte Preta
-Atletico GO	1 - 1	Botafogo
+Atlético GO	1 - 1	Botafogo
 [Seg, 24/07]
 São Paulo	1 - 1	Grêmio
 
@@ -239,14 +239,14 @@ Rodada 17
 Botafogo	3 - 4	São Paulo
 Palmeiras	2 - 0	Avaí
 [Dom, 30/07]
-Chapeconse	1 - 2	Atlético GO
+Chapecoense	1 - 2	Atlético GO
 Corinthians	1 - 1	Flamengo
 Coritiba	0 - 2	Atlético MG
 Bahia		1 - 3	Sport
 Cruzeiro	0 - 0	Vitória
 Grêmio		1 - 1	Santos
 [Seg, 31/07]
-Vasco		0 - 1	Atlético PR
+Vasco da Gama	0 - 1	Atlético PR
 [Qua, 09/08]
 Ponte Preta	0 - 0	Fluminense
 
@@ -262,7 +262,7 @@ Atlético GO	0 - 1	Grêmio
 [Qui, 03/08]
 São Paulo	1 - 2	Coritiba
 Atlético PR	5 - 0	Avaí
-Vasco		0 - 3	Cruzeiro
+Vasco da Gama		0 - 3	Cruzeiro
 
 Rodada 19
 [Sáb, 05/08]
@@ -270,12 +270,12 @@ Fluminense	3 - 1	Atlético GO
 Corinthians	3 - 1	Sport
 [Dom, 06/08]
 Flamengo	0 - 2	Vitória
-Palmeiras	0 - 1	Altético PR
+Palmeiras	0 - 1	Atlético PR
 Cruzeiro	0 - 0	Botafogo
 Coritiba	2 - 0	Chapecoense
 Grêmio		2 - 0	Atlético MG
 Bahia		2 - 1	São Paulo
-Ponte Preta	0 - 0	Vasco
+Ponte Preta	0 - 0	Vasco da Gama
 Avaí		0 - 0	Santos
 
 Rodada 20
@@ -284,40 +284,40 @@ Atlético GO	1 - 0	Coritiba
 Vitória		0 - 1	Avaí
 [Dom, 13/08]
 São Paulo	3 - 2	Cruzeiro
-Vasco		1 - 1	Palmeiras
-Altético MG	2 - 0	Flamengo
+Vasco da Gama	1 - 1	Palmeiras
+Atlético MG	2 - 0	Flamengo
 Sport		0 - 0	Ponte Preta
 Botafogo	1 - 0	Grêmio
 Atlético PR	4 - 1 	Bahia
 [Seg, 14/08]
 Santos		0 - 0	Fluminense
 [Qua, 23/08]
-Chapecoense	0 - 0	Corinthians
+Chapecoense	0 - 1	Corinthians
 
 Rodada 21
 [Sáb, 19/08]
 Corinthians	0 - 1	Vitória
-Flamengo	2 - 0	Altético GO
+Flamengo	2 - 0	Atlético GO
 [Dom, 20/08]
-Grêmio		0 - 0	Altético PR
+Grêmio		0 - 0	Atlético PR
 Cruzeiro	2 - 0	Sport
-Bahia		3 - 0	Vasco
+Bahia		3 - 0	Vasco da Gama
 Ponte Preta	2 - 1	Botafogo
 Avaí		1 - 1	São Paulo
 Palmeiras	0 - 2	Chapecoense
 Coritiba	0 - 0	Santos
 [Seg, 21/08]
-Fluminense	2 - 1	Altético MG
+Fluminense	2 - 1	Atlético MG
 
 Rodada 22
 [Sáb, 26/08]
-Fluminense	0 - 1	Vasco
+Fluminense	0 - 1	Vasco da Gama
 Corinthians	0 - 1	Atlético GO
 [Dom, 27/08]
-Flamengo	2 - 0	Altético PR
+Flamengo	2 - 0	Atlético PR
 Palmeiras	4 - 2	São Paulo
 Bahia		1 - 2	Botafogo
-Ponte Preta	1 - 2	Altético MG
+Ponte Preta	1 - 2	Atlético MG
 Cruzeiro	1 - 1	Santos
 Avaí		1 - 0	Chapecoense
 [Seg, 28/08]
@@ -327,13 +327,13 @@ Grêmio		5 - 0	Sport
 
 Rodada 23
 [Sáb, 09/09]
-Altético MG	1 - 1	Palmeiras
-Vasco		1 - 0	Grêmio
+Atlético MG	1 - 1	Palmeiras
+Vasco da Gama	1 - 0	Grêmio
 São Paulo	2 - 2	Ponte Preta
 [Dom, 10/09]
 Atlético PR	1 - 1	Coritiba
-Santos		2 - 0	Santos
-Sport		0 - 1	Corinthians
+Santos		2 - 0	Corinthians
+Sport		0 - 1	Avaí
 Vitória		2 - 2	Fluminense
 Botafogo	2 - 0	Flamengo
 Chapecoense	1 - 2	Cruzeiro
@@ -345,9 +345,9 @@ Rodada 24
 Botafogo	2 - 0	Santos
 Ponte Preta	1 - 3	Atlético GO
 [Dom, 17/09]
-Avaí		1 - 1	Altético MG
+Avaí		1 - 1	Atlético MG
 Flamengo	2 - 0	Sport
-Corinthians	1 - 0	Vasco
+Corinthians	1 - 0	Vasco da Gama
 Atlético PR	3 - 1	Fluminense
 Grêmio		0 - 1	Chapecoense
 Vitória		1 - 2	São Paulo
@@ -368,11 +368,11 @@ Chapecoense	1 - 0	Ponte Preta
 Atlético MG	1 - 3	Vitória
 Bahia		1 - 0	Grêmio
 [Seg, 25/09]
-Sport		1 - 1	Vasco
+Sport		1 - 1	Vasco da Gama
 
 Rodada 26
 [Sáb, 30/09]
-Vasco		1 - 1	Chapecoense
+Vasco da Gama	1 - 1	Chapecoense
 Bahia		1 - 1	Coritiba
 Palmeiras	0 - 1	Santos
 [Dom, 01/10]
@@ -388,11 +388,11 @@ Ponte Preta	1 - 0	Flamengo
 Rodada 27
 [Qua, 11/10]
 Botafogo	2 - 1	Chapecoense
-Altético PR	2 - 2	Atlético GO
+Atlético PR	2 - 2	Atlético GO
 Corinthians	3 - 1	Coritiba
 Atlético MG	1 - 0	São Paulo
 Grêmio		0 - 1	Cruzeiro
-Avaí		1 - 2	Vasco
+Avaí		1 - 2	Vasco da Gama
 [Qui, 12/10]
 Flamengo	1 - 1	Fluminense
 Vitória		1 - 2	Sport
@@ -403,12 +403,12 @@ Rodada 28
 [Sáb, 07/10]
 Cruzeiro	2 - 1	Ponte Preta
 [Sáb, 14/10]
-Vasco		1 - 0	Botafogo
-São Paulo	2 - 1	Altético PR
+Vasco da Gama	1 - 0	Botafogo
+São Paulo	2 - 1	Atlético PR
 [Dom, 15/10]
 Fluminense	1 - 0	Avaí
 Sport		1 - 1	Atlético MG
-Altético GO	1 - 3	Palmeiras
+Atlético GO	1 - 3	Palmeiras
 Chapecoense	0 - 1	Flamengo
 Coritiba	0 - 1	Grêmio
 Bahia		2 - 0	Corinthians
@@ -418,22 +418,22 @@ Santos		2 - 2	Vitória
 Rodada 29
 [Qua, 18/10]
 Coritiba	1 - 0	Cruzeiro
-Atlético GO	0 - 1	Vasco
+Atlético GO	0 - 1	Vasco da Gama
 Atlético MG	2 - 3	Chapecoense
 Fluminense	3 - 1	São Paulo
 Corinthians	0 - 0	Grêmio
 Avaí		1 - 1	Botafogo
 [Qui, 19/10]
 Palmeiras	2 - 0	Ponte Preta
-Vitória		2 - 3	Altético PR
+Vitória		2 - 3	Atlético PR
 Flamengo	4 - 1	Bahia
 Sport		1 - 1	Santos
 
 Rodada 30
 [Sáb, 21/10]
-Vasco		1 - 1	Coritiba
+Vasco da Gama	1 - 1	Coritiba
 [Dom, 22/10]
-Santos		1 - 0	Atletico GO
+Santos		1 - 0	Atlético GO
 São Paulo	2 - 0	Flamengo
 Cruzeiro	1 - 3	Atlético MG
 Atlético PR	2 - 1	Sport
@@ -447,11 +447,11 @@ Botafogo	2 - 1	Corinthians
 Rodada 31
 [Sáb, 28/10]
 São Paulo	2 - 1	Santos
-Flamengo	0 - 0	Vasco
+Flamengo	0 - 0	Vasco da Gama
 Atlético PR	0 - 0	Chapecoense
 [Dom, 29/10]
 Fluminense	1 - 1	Bahia
-Altético MG	0 - 0	Botafogo
+Atlético MG	0 - 0	Botafogo
 Ponte Preta	1 - 0	Corinthians
 Sport		3 - 4	Coritiba
 Vitória		1 - 1	Atlético GO
@@ -470,7 +470,7 @@ Corinthians	3 - 2	Palmeiras
 Cruzeiro	1 - 0	Atlético PR
 Grêmio		3 - 1	Flamengo
 Bahia		2 - 0	Ponte Preta
-Vasco		1 - 1	Vitória
+Vasco da Gama	1 - 1	Vitória
 Chapecoense	1 - 1	Sport
 
 Rodada 33
@@ -480,11 +480,11 @@ Avaí		1 - 2	Bahia
 Atlético PR	0 - 1	Corinthians
 Sport		1 - 2	Botafogo
 Flamengo	2 - 0	Cruzeiro
-Santos		1 - 2	Vasco
+Santos		1 - 2	Vasco da Gama
 Vitória		3 - 1	Palmeiras
 [Qui, 09/11]
 São Paulo	2 - 2	Chapecoense
-Altético MG	3 - 2	Atlético GO
+Atlético MG	3 - 2	Atlético GO
 Fluminense	2 - 2	Coritiba
 
 Rodada 34
@@ -492,7 +492,7 @@ Rodada 34
 Botafogo	0 - 1	Atlético PR
 Corinthians	1 - 0	Avaí
 [Dom, 12/11]
-Vasco		1 - 1	São Paulo
+Vasco da Gama	1 - 1	São Paulo
 Palmeiras	2 - 0	Flamengo
 Grêmio		1 - 1	Vitória
 Atlético GO	2 - 0	Sport
@@ -505,14 +505,15 @@ Chapecoense	2 - 0	Santos
 Rodada 35
 [Qua, 15/11]
 Ponte Preta	2 - 1	Atlético PR
-Cruzeiro	2 - 2	Avai
+Cruzeiro	2 - 2	Avaí
 Grêmio		1 - 0	São Paulo
-Vasco		1 - 1	Atlético MG
+Vasco da Gama	1 - 1	Atlético MG
 Corinthians	3 - 1	Fluminense
 [Qui, 16/11]
 Botafogo	1 - 2	Atlético GO
 Palmeiras	5 - 1	Sport
-Chapecoense	1 - 0	Flamengo
+Chapecoense     2 - 1   Vitória
+Coritiba	1 - 0	Flamengo
 Bahia		3 - 1	Santos
 
 Rodada 36
@@ -523,8 +524,8 @@ Sport		1 - 0	Bahia
 Vitória		1 - 1	Cruzeiro
 Atlético GO	1 - 1	Chapecoense
 Santos		1 - 0 	Grêmio
-Atletico MG	3 - 0	Coritiba
-Altético PR	3 - 1	Vasco
+Atlético MG	3 - 0	Coritiba
+Atlético PR	3 - 1	Vasco da Gama
 [Seg, 20/11]
 Fluminense	2 - 0	Ponte Preta
 Avaí		2 - 1	Palmeiras
@@ -533,12 +534,12 @@ Rodada 37
 [Sáb, 25/11]
 Fluminense	1 - 2	Sport
 [Dom, 26/11]
-Corinthians	2 - 2	Altético MG
-Cruzeiro	0 - 1	Vasco
+Corinthians	2 - 2	Atlético MG
+Cruzeiro	0 - 1	Vasco da Gama
 Coritiba	1 - 2	São Paulo
 Grêmio		1 - 1	Atlético GO
 Ponte Preta	2 - 3	Vitória
-Avaí		1 - 0	Altético PR
+Avaí		1 - 0	Atlético PR
 Flamengo	1 - 2	Santos
 Bahia		0 - 1	Chapecoense
 [Seg, 27/11]
@@ -547,12 +548,12 @@ Palmeiras	2 - 0	Botafogo
 Rodada 38
 [Dom, 03/12]
 Botafogo	2 - 2	Cruzeiro
-Vasco		2 - 1	Ponte Preta
+Vasco da Gama	2 - 1	Ponte Preta
 Santos		1 - 1	Avaí
 São Paulo	1 - 1	Bahia
 Atlético MG	4 - 3	Grêmio
-Altético PR	3 - 0	Palmeiras
+Atlético PR	3 - 0	Palmeiras
 Sport		1 - 0	Corinthians
 Vitória		1 - 2	Flamengo
 Atlético GO	1 - 1	Fluminense
-Chapencoense	2 - 1	Coritiba
+Chapecoense	2 - 1	Coritiba


### PR DESCRIPTION
I fixed some commom errors like in some matches we had only the name Atlético without distinct if it was Atlético MG, PR or GO. In another cases we have missing matches or wrong results, beyond mispelling.

These fixes were based on this reference: https://esportes.estadao.com.br/classificacao/futebol/campeonato-brasileiro-serie-a/2017 .