### PR TITLE
Update brasileirao-seriea.txt

### DIFF
--- a/2005/brasileirao-seriea.txt
+++ b/2005/brasileirao-seriea.txt
@@ -379,8 +379,7 @@
 21h45 - Paysandu 2 - 2 Ponte Preta - Mangueirão
 
 08/09/2005 - Quinta-ferira
-20h30 - Flamengo 1 - 1 Internacional -  - Luso
-Brasileiro
+20h30 - Flamengo 1 - 1 Internacional -  - Luso Brasileiro
 20h30 - Palmeiras 1 - 1 Coritiba - Parque Antártica
 
 25 Rodada


### PR DESCRIPTION
Rodada 24 (line 382) had a stadium name ("Luso Brasileiro") broken in 2 lines by mistake. I backspaced the second part to its right position, so the full name will be in the same line.